### PR TITLE
feat: add new title do create habit drawer

### DIFF
--- a/src/components/create-habit-drawer.tsx
+++ b/src/components/create-habit-drawer.tsx
@@ -20,7 +20,7 @@ export async function CreateHabitDrawer() {
       </DrawerTrigger>
       <DrawerContent>
         <DrawerHeader>
-          <DrawerTitle></DrawerTitle>
+          <DrawerTitle>Create a new Habit</DrawerTitle>
         </DrawerHeader>
         <DrawerFooter>
           <HabitForm />


### PR DESCRIPTION
I think the problem is with Shadcns drawer component. It only happens if you press the first input in the form. And it only happens in Safari on mobile. I've added a little title to the drawer because I think the problem is that the input is shown above the keyboard and because of that the drawer isn't "pushed" up. By adding the title the input should now be below the keyboard hence it should be pushed up. It's very hard to test because I only get this on my phone in production. It works as intended in the Simulator. So I think this is a good test to see if I'm right.